### PR TITLE
.gitignore - ignore certbot keys

### DIFF
--- a/update-ignore.d/01update-ignore
+++ b/update-ignore.d/01update-ignore
@@ -144,6 +144,12 @@ writefile () {
 	ignore "#*#"
 	ignore DEADJOE
 
+	comment "ignore certbot/letsencrypt certs"
+	ignore letsencrypt/keys
+	ignore letsencrypt/archive
+	ignore letsencrypt/live
+	ignore letsencrypt/csr
+
 	nl
 	comment "end section $managed_by_etckeeper"
 }


### PR DESCRIPTION
Storing certbot/letsencrypt keys in the repo takes considerable space, specially when having many domains over long time.
...and obviously is a security risk

I have not fully tested yet, but with those rules we should still keep trace of certbot setup,  at disaster this should be good enough to  re-create all new certificates at once.

There probably is a more elegant way do this, but I think it would be a good idea not to store those keys by default.

Thanks for your great work, this package is very handy and made this world a better place :)
